### PR TITLE
Update example to tabris-js@2.0.0-beta1 API

### DIFF
--- a/example/www/app.js
+++ b/example/www/app.js
@@ -8,9 +8,7 @@ var navigationView = new tabris.NavigationView({
 
 var mainPage = new tabris.Page({
   title: 'Firebase examples'
-});
-
-navigationView.stack.push(mainPage);
+}).appendTo(navigationView);
 
 pages.forEach(createPageButton);
 
@@ -20,6 +18,6 @@ function createPageButton(pageConstructor) {
     left: 16, top: 'prev() 16', right: 16,
     text: 'Show \'' + page.title.toLowerCase() + '\' example'
   }).on('select', function() {
-    navigationView.stack.push(page);
+    page.appendTo(navigationView);
   }).appendTo(mainPage);
 }

--- a/example/www/package.json
+++ b/example/www/package.json
@@ -3,6 +3,6 @@
   "description": "Example for the Tabris firebase plugin.",
   "main": "app.js",
   "dependencies": {
-    "tabris": "https://tabrisjs.com/downloads/nightly-2.x/tabris.tgz"
+    "tabris": "2.0.0-beta1"
   }
 }


### PR DESCRIPTION
NavigationView does not support the 'stack' property anymore. Pages
should be appended to it instead of pushing them to a stack.

Pin Tabris.js module dependency to 2.0.0-beta1.