### PR TITLE
Fix example icon paths

### DIFF
--- a/example/config.xml
+++ b/example/config.xml
@@ -9,7 +9,7 @@
   <preference name="EnableDeveloperConsole" value="true" />
 
   <plugin name="tabris-plugin-firebase" spec="1.0.0">
-    <variable name="ANDROID_NOTIFICATION_ICON" value="ic_stat_trend" />
+    <variable name="ANDROID_NOTIFICATION_ICON" value="@drawable/ic_stat_trend" />
   </plugin>
 
   <hook type="after_prepare" src="scripts/android/copy_icons.js" />

--- a/example/scripts/android/copy_icons.js
+++ b/example/scripts/android/copy_icons.js
@@ -10,8 +10,11 @@ const files = [
 files.forEach(file => {
   const src = path.join('res/android', file);
   const dst = path.join('platforms/android/res', file);
-  if (fs.existsSync(src) && fs.existsSync(path.dirname(dst))) {
-    console.log(`copying ${src} to ${dst}`);
-    fs.createReadStream(src).pipe(fs.createWriteStream(dst));
+  const dstDirname = path.dirname(dst);
+  if (!fs.existsSync(src)) return;
+  if (!fs.existsSync(dstDirname)) {
+    fs.mkdirSync(dstDirname);
   }
+  console.log(`copying ${src} to ${dst}`);
+  fs.createReadStream(src).pipe(fs.createWriteStream(dst));
 });


### PR DESCRIPTION
drawable-xhdpi does not exist anymore in the platform, so it should be
explicitly created.

Prepend '@drawable/' to the resource name, since it is an Android
drawable resource [1].

[1]: https://developer.android.com/guide/topics/resources/drawable-resource.html
