### PR TITLE
Add support for Firebase Realtime Database (Preview)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,10 @@
     <clobbers target="firebase.Analytics" />
   </js-module>
 
+  <js-module src="www/Reference.js" name="reference">
+    <clobbers target="firebase.Reference" />
+  </js-module>
+
 
   <platform name="android">
 
@@ -54,9 +58,9 @@
           android:name="com.eclipsesource.tabris.android.OPERATOR.com.eclipsesource.tabris.firebase.analytics"
           android:value="com.eclipsesource.firebase.analytics.AnalyticsOperator" />
       <meta-data
-          android:name="com.google.firebase.messaging.default_notification_icon"
-          android:resource="$ANDROID_NOTIFICATION_ICON" />
-      <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
+        android:name="com.eclipsesource.tabris.android.OPERATOR.com.eclipsesource.tabris.firebase.reference"
+        android:value="com.eclipsesource.firebase.reference.ReferenceOperator" />
+     <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
 
       <receiver android:name="com.eclipsesource.firebase.messaging.NotificationOpenedReceiver" />
 
@@ -66,6 +70,7 @@
 
     <framework src="com.google.firebase:firebase-messaging:10.2.1" />
     <framework src="com.google.firebase:firebase-analytics:10.2.1" />
+    <framework src="com.google.firebase:firebase-database:10.2.1" />
 
     <source-file src="src/android/com/eclipsesource/firebase/messaging/MessagingOperator.java"
                  target-dir="src/com/eclipsesource/firebase/messaging" />
@@ -86,6 +91,14 @@
                  target-dir="src/com/eclipsesource/firebase/analytics" />
     <source-file src="src/android/com/eclipsesource/firebase/analytics/Analytics.java"
                  target-dir="src/com/eclipsesource/firebase/analytics" />
+                 
+    
+    <source-file src="src/android/com/eclipsesource/firebase/reference/ReferenceOperator.java"
+                 target-dir="src/com/eclipsesource/firebase/reference" />
+    <source-file src="src/android/com/eclipsesource/firebase/reference/ReferencePropertyHandler.java"
+                 target-dir="src/com/eclipsesource/firebase/reference" />
+    <source-file src="src/android/com/eclipsesource/firebase/reference/Reference.java"
+                 target-dir="src/com/eclipsesource/firebase/reference" />
 
     <hook src="scripts/android/copy_google_services.js" type="after_prepare" />
 

--- a/project/android/firebase/build.gradle
+++ b/project/android/firebase/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile 'com.eclipsesource.tabris:tabris-android:2.0.0'
     compile "com.google.firebase:firebase-messaging:$playServicesVersion"
     compile "com.google.firebase:firebase-analytics:$playServicesVersion"
+    compile "com.google.firebase:firebase-database:$playServicesVersion"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'

--- a/src/android/com/eclipsesource/firebase/reference/Reference.java
+++ b/src/android/com/eclipsesource/firebase/reference/Reference.java
@@ -1,0 +1,182 @@
+package com.eclipsesource.firebase.reference;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.support.v4.content.LocalBroadcastManager;
+import android.util.Log;
+
+import com.eclipsesource.tabris.android.RemoteObject;
+import com.eclipsesource.tabris.android.TabrisActivity;
+import com.eclipsesource.tabris.android.TabrisContext;
+import com.eclipsesource.tabris.android.internal.toolkit.AppState;
+import com.eclipsesource.tabris.android.internal.toolkit.IAppStateListener;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.firebase.database.ChildEventListener;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+
+
+class Reference { //Represents DatabaseReference... or should it represent FirebaseDatabase ?
+    private DatabaseReference database;
+
+    private final Activity activity;
+    private final TabrisContext tabrisContext;
+    private String path;
+
+    Reference(Activity activity, TabrisContext context){
+        this.activity = activity;
+        this.tabrisContext = context;
+        Log.e("Nery", "Reference created");
+        if(this.activity == null){
+            Log.e("ERROR", "activity es null");
+        }
+        if(this.tabrisContext == null){
+            Log.e("ERROR", "tabrisContext es null");
+        }
+    }
+
+
+    public void create(DatabaseReference ref){
+        this.path = ref.toString();
+        this.database = ref;
+        registerListeners();
+    }
+
+
+    public Reference child(String path){
+        Reference ref = new Reference(this.activity, this.tabrisContext);
+        ref.create(this.database.child(path));
+        return ref;
+    }
+    
+    public Reference push(){
+        Reference ref = new Reference(this.activity, this.tabrisContext);
+        ref.create(this.database.push());
+        return ref;
+    }
+
+    public void keepSynced(boolean keepSynced){
+        this.database.keepSynced(keepSynced);
+    }
+
+    public void setValue(Object value){
+        //Set the value and add a CompletitionListener
+        database.setValue(value, completition);
+    }
+
+    public String getKey(){
+        return this.database.getKey();
+    }
+
+
+
+
+    private void registerListeners(){
+        database.addValueEventListener(valueListener);   
+
+        database.addChildEventListener(childlistener);
+    }
+    
+    private DatabaseReference.CompletionListener completition = new DatabaseReference.CompletionListener() {
+        @Override
+        public void onComplete(DatabaseError error, DatabaseReference ref){
+            Log.e("Nery", "Saved");
+            final RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) {
+                if(error != null){
+                    //... notify if there was an error.
+                    remoteObject.notify("ErrorSaving", "error", error.getMessage());
+                } else {
+                    //... if everything OK, 
+                    ref.addListenerForSingleValueEvent(new ValueEventListener() {
+                        @Override
+                        public void onDataChange(DataSnapshot dataSnapshot) {
+                            // notify that tha value was saved.
+                            remoteObject.notify("onValueSaved", "value", dataSnapshot.getValue());
+                        }
+                        @Override public void onCancelled(DatabaseError databaseError) {}
+                    });
+                }
+            }
+        }
+    };
+
+    private ValueEventListener valueListener = new ValueEventListener() {
+        @Override
+        public void onDataChange(final DataSnapshot dataSnapshot) {
+            Log.e("Nery", "Changed..!");
+            if(activity == null){
+                Log.e("ERROR", "activity es null");
+            }
+            if(tabrisContext == null){
+                Log.e("ERROR", "tabrisContext es null");
+            }
+            RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) remoteObject.notify("onDataChange", "data", dataSnapshot.getValue());
+        }
+        @Override public void onCancelled(DatabaseError databaseError) {}
+    };
+    
+    private ChildEventListener childlistener = new ChildEventListener(){
+        @Override
+        public void onCancelled(DatabaseError error){
+            RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) remoteObject.notify("onCancelled", "error", error.getMessage());
+        }
+        @Override
+        public void onChildAdded(DataSnapshot snapshot, String previousChildName){
+            Map<String, Object> map = new HashMap();
+            map.put("child", snapshot.getKey());
+            map.put("value", snapshot.getValue());
+            RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) remoteObject.notify("onChildAdded", map);
+        }
+        @Override
+        public void onChildChanged(DataSnapshot snapshot, String previousChildName){
+            Map<String, Object> map = new HashMap();
+            map.put("child", snapshot.getKey());
+            map.put("value", snapshot.getValue());
+            RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) remoteObject.notify("onChildChanged", map);
+        }
+        @Override
+        public void onChildMoved(DataSnapshot snapshot, String previousChildName){
+            Map<String, Object> map = new HashMap();
+            map.put("child", snapshot.getKey());
+            map.put("value", snapshot.getValue());
+            RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) remoteObject.notify("onChildMoved", map);
+        }
+        @Override
+        public void onChildRemoved(DataSnapshot snapshot){
+            Map<String, Object> map = new HashMap();
+            map.put("child", snapshot.getKey());
+            map.put("value", snapshot.getValue());
+            RemoteObject remoteObject = tabrisContext.getObjectRegistry().getRemoteObjectForObject(Reference.this);
+            if (remoteObject != null) remoteObject.notify("onChildRemoved", map);
+        }
+    };
+
+
+
+    public void unregisterAllListeners() {
+       this.database.removeEventListener(valueListener);
+       this.database.removeEventListener(childlistener);
+    }
+    
+
+}

--- a/src/android/com/eclipsesource/firebase/reference/ReferenceOperator.java
+++ b/src/android/com/eclipsesource/firebase/reference/ReferenceOperator.java
@@ -1,0 +1,83 @@
+package com.eclipsesource.firebase.reference;
+
+import android.app.Activity;
+
+import com.eclipsesource.tabris.android.AbstractOperator;
+import com.eclipsesource.tabris.android.Properties;
+import com.eclipsesource.tabris.android.PropertyHandler;
+import com.eclipsesource.tabris.android.TabrisContext;
+
+
+import android.util.Log;
+
+
+import com.google.firebase.database.FirebaseDatabase;
+
+public class ReferenceOperator extends AbstractOperator<Reference> {
+
+  private static final String TYPE = "com.eclipsesource.firebase.Reference";
+
+
+  
+  private static final String METHOD_SET_VALUE = "setValue";
+  private static final String METHOD_CHILD = "child";
+  private static final String METHOD_PUSH = "push";
+  private static final String METHOD_GET_KEY = "getKey";
+  private static final String METHOD_KEEP_SYNCED = "keepSynced";
+  private static final String METHOD_CREATE = "create";
+  private static final String METHOD_REGISTER_LISTENERS = "registerListeners";
+
+
+
+
+  private final Activity activity;
+  private final TabrisContext tabrisContext;
+  private final ReferencePropertyHandler propertyHandler;
+
+  public ReferenceOperator(Activity activity, TabrisContext tabrisContext) {
+    this.activity = activity;
+    this.tabrisContext = tabrisContext;
+    propertyHandler = new ReferencePropertyHandler();
+  }
+
+  @Override
+  public PropertyHandler<Reference> getPropertyHandler(Reference ref) {
+    return propertyHandler;
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  @Override
+  public Reference create(String id, Properties properties) {
+    FirebaseDatabase firebase = FirebaseDatabase.getInstance();;
+    Reference ref = new Reference(this.activity, this.tabrisContext);
+    return ref;
+  }
+
+  @Override
+  public Object call(Reference ref, String method, Properties properties) {
+    switch (method) {
+      case METHOD_CREATE:
+        ref.create(FirebaseDatabase.getInstance().getReference(properties.getString("path")));
+        break;
+      case METHOD_PUSH:
+        return ref.push().getKey(); 
+      case METHOD_KEEP_SYNCED:
+        ref.keepSynced(properties.getBooleanSafe("keepSynced"));
+        break;
+      case METHOD_SET_VALUE:
+        ref.setValue(properties.get("value"));
+        break;
+    }
+    return null;
+  }
+
+  @Override
+  public void destroy(Reference ref) {
+    ref.unregisterAllListeners();
+  }
+
+}

--- a/src/android/com/eclipsesource/firebase/reference/ReferencePropertyHandler.java
+++ b/src/android/com/eclipsesource/firebase/reference/ReferencePropertyHandler.java
@@ -1,0 +1,24 @@
+package com.eclipsesource.firebase.reference;
+
+import com.eclipsesource.tabris.android.Properties;
+import com.eclipsesource.tabris.android.PropertyHandler;
+
+class ReferencePropertyHandler implements PropertyHandler<Reference> {
+
+  private static final String PROP_KEY = "key";
+
+  @Override
+  public Object get(Reference reference, String property) {
+    switch (property) {
+      case PROP_KEY:
+        return reference.getKey();
+    }
+    return null;
+  }
+
+  @Override
+  public void set(Reference reference, Properties properties) {
+    // setting any properties is not supported
+  }
+
+}

--- a/www/Reference.js
+++ b/www/Reference.js
@@ -1,0 +1,56 @@
+
+const EVENT_TYPES = ['onValueSaved', 'ErrorSaving', 'onDataChange',      
+    'onCancelled', 'onChildAdded', 'onChildChanged', 'onChildMoved', 'onChildRemoved'];
+
+const readOnly = {
+  set: name => console.warn(`Can not set read-only property "${name}"`)
+};
+
+class Reference extends tabris.NativeObject {
+    
+  constructor(path) {
+    super();
+    console.error("Path: " + path);
+    this._create('com.eclipsesource.firebase.Reference', {path: path});
+    this._nativeCall('create', {path: path});
+    this.path = path;
+  }
+
+  _listen(name, listening) {
+    if (EVENT_TYPES.indexOf(name) > -1) {
+      this._nativeListen(name, listening);
+    } else {
+      super._listen(name, listening);
+    }
+  }
+
+  _dispose() {
+    throw new Error('DatabaseReference can not be disposed...?');
+  }
+
+
+
+  child(path){
+      return new Reference(this.path + "/" + path);
+  }
+
+  setValue(value) {
+    this._nativeCall('setValue', {value: value ? value : {}});
+    return this;
+  }
+
+  push(){
+    return new Reference(this.path + "/" + this._nativeCall('push', {}));
+  }
+
+  keepSynced(keep){
+    this._nativeCall('keepSynced', {keepSynced: keep});
+    return this;
+  }
+
+}
+tabris.NativeObject.defineProperties(Reference.prototype, {
+  key: {type: 'string', nocache: true, access: readOnly},
+});
+
+module.exports = Reference;


### PR DESCRIPTION
This is a preview of the support for the Realtime Database (Just for Android).

Please, test it for bugs and improvements, and help with ios implementation 😀 

To get a reference node on the database:
`var ref = new firebase.Reference("path");`

To save data on the reference:
`ref.setValue(value);`

Listeners can be set using ref.on('event', listener) with the following events (some are likely to change):

Saving a value:
`onValueSaved`, `ErrorSaving`
Value listener
`onDataChanged`
Child listeners
`onCancelled`, `onChildAdded`, `onChildChanged`, `onChildRemoved`
Example:
```

ref.on(
    'onChildAdded', 
    (event) => {
        textView.text = event.child + ": " + event.value; 
    }
)
```
Other functions:

- `child(path)`
- `getKey()`
- `push()` returns a new `Reference`, child of this one.
- `keepSynced(boolean)`

Note: I'll be working on the implementation of the `FirebaseDatabase`, to have access to `setPersistenceEnable()` and maybe some other functions. This is just a preview.