### PR TITLE
Modernize example

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,3 +1,4 @@
+const {CollectionView, Composite, NavigationView, Page, TextView, ui} = require('tabris');
 const MessagingPage = require('./pages/messaging');
 const AnalyticsPage = require('./pages/analytics');
 const res = require('./resources');
@@ -5,44 +6,44 @@ const res = require('./resources');
 const MARGIN = res.dimen.margin;
 const MARGIN_LARGE = res.dimen.marginLarge;
 
-const pages = [new MessagingPage(), new AnalyticsPage()];
+let pages = [new MessagingPage(), new AnalyticsPage()];
 
-const navigationView = new tabris.NavigationView({
+let navigationView = new NavigationView({
   left: 0, top: 0, right: 0, bottom: 0
-}).appendTo(tabris.ui.contentView);
+}).appendTo(ui.contentView);
 
-const mainPage = new tabris.Page({
+let mainPage = new Page({
   title: 'Firebase Examples',
   background: res.color.pageBackground
 }).appendTo(navigationView);
 
-new tabris.CollectionView({
+new CollectionView({
   left: 0, top: 0, right: 0, bottom: 0,
   itemCount: pages.length,
-  cellHeight: (index) => index === 0 ? 96 : 88,
+  cellHeight: index => index === 0 ? 96 : 88,
   createCell: () => {
-    const composite = new tabris.Composite({highlightOnTouch: true});
-    new tabris.TextView({
+    let composite = new Composite({highlightOnTouch: true});
+    new TextView({
       id: 'titleView',
       left: MARGIN, right: MARGIN, top: MARGIN,
       maxLines: 1,
       font: '16px',
       textColor: res.color.textPrimary
     }).appendTo(composite);
-    new tabris.TextView({
+    new TextView({
       id: 'descriptionView',
       maxLines: 2,
-      left: MARGIN, top: ['prev()', 0], right: MARGIN,
+      left: MARGIN, top: 'prev()', right: MARGIN,
       font: '14px',
       textColor: res.color.textSecondary
     }).appendTo(composite);
     return composite;
   },
   updateCell: (cell, index) => {
-    const titleView = cell.find('#titleView').first();
+    let titleView = cell.find('#titleView').first();
     titleView.text = pages[index].title;
     titleView.top = index === 0 ? MARGIN_LARGE : MARGIN;
-    cell.find('#descriptionView').first().text = pages[index].description;
+    cell.find('#descriptionView').first().text = pages[index].DESCRIPTION;
   }
 }).on('select', ({index}) => pages[index].appendTo(navigationView))
   .appendTo(mainPage);

--- a/example/src/pages/analytics.js
+++ b/example/src/pages/analytics.js
@@ -1,3 +1,4 @@
+const {Composite, CheckBox, Page, ScrollView, TextInput, TextView} = require('tabris');
 const Card = require('../widgets/Card');
 const FlatButton = require('../widgets/FlatButton');
 const res = require('../resources');
@@ -6,40 +7,43 @@ const MARGIN_SMALL = res.dimen.marginSmall;
 const MARGIN = res.dimen.margin;
 const MARGIN_LARGE = res.dimen.marginLarge;
 
-module.exports = class AnalyticsPage extends tabris.Page {
+module.exports = class AnalyticsPage extends Page {
 
   constructor(properties) {
-    super(properties);
-    this.title = 'Firebase Analytics';
-    this.description = 'Use Analytics to log events, track app navigation and record custom user properties.';
-    this.autoDispose = false;
-    this.background = res.color.pageBackground;
-    this.once('appear', this._createPageContent);
+    super(Object.assign({
+      title: 'Firebase Analytics',
+      autoDispose: false,
+      background: res.color.pageBackground
+    }, properties));
+    this._createContent();
   }
 
-  _createPageContent({target: page}) {
+  get DESCRIPTION() {
+    return 'Use Analytics to log events, track app navigation and record custom user properties.';
+  }
 
+  _createContent() {
     firebase.Analytics.analyticsCollectionEnabled = true;
     firebase.Analytics.screenName = 'details_screen';
     firebase.Analytics.userId = 'anonymous_user_id';
     firebase.Analytics.setUserProperty('priority_customer', 'true');
 
-    const scrollView = new tabris.ScrollView({
+    let scrollView = new ScrollView({
       left: 0, right: 0, top: 0, bottom: 0
-    }).appendTo(page);
+    }).appendTo(this);
 
-    let generalCard = new Card({title: 'General'}).appendTo(scrollView);
+    let generalCard = this._createCard('General').appendTo(scrollView);
 
-    new tabris.CheckBox({
+    new CheckBox({
       left: MARGIN, top: ['prev()', MARGIN], right: MARGIN, bottom: MARGIN,
       text: 'Collect analytics data',
       checked: true
     }).on('checkedChanged', ({value: checked}) => firebase.Analytics.analyticsCollectionEnabled = checked)
       .appendTo(generalCard);
 
-    let screenNameCard = new Card({title: 'Screen name'}).appendTo(scrollView);
+    let screenNameCard = this._createCard('Screen name').appendTo(scrollView);
 
-    const screenName = new tabris.TextInput({
+    let screenName = new TextInput({
       left: MARGIN, right: MARGIN, top: ['prev()', MARGIN_SMALL],
       message: 'Screen name',
       text: 'details_screen'
@@ -51,47 +55,47 @@ module.exports = class AnalyticsPage extends tabris.Page {
     }).on('tap', () => firebase.Analytics.screenName = screenName.text)
       .appendTo(screenNameCard);
 
-    let eventCard = new Card({title: 'Event logging'}).appendTo(scrollView);
+    let eventCard = this._createCard('Event logging').appendTo(scrollView);
 
-    new tabris.TextView({
+    new TextView({
       left: MARGIN, right: MARGIN, top: ['prev()', MARGIN_LARGE],
       text: 'Event name',
       font: 'medium 14px',
       textColor: res.color.textInputLabel
     }).appendTo(eventCard);
 
-    const eventName = new tabris.TextInput({
+    let eventName = new TextInput({
       id: 'eventNameTextInput',
       left: MARGIN, right: MARGIN, top: 'prev()',
       message: 'Event name',
       text: 'select_content'
     }).appendTo(eventCard);
 
-    new tabris.TextView({
+    new TextView({
       left: MARGIN, right: MARGIN, top: ['prev()', MARGIN_LARGE],
       text: 'Event data',
       font: 'medium 14px',
       textColor: res.color.textInputLabel
     }).appendTo(eventCard);
 
-    const logKey1 = new tabris.TextInput({
+    let logKey1 = new TextInput({
       left: MARGIN, right: ['#logValue1', MARGIN], top: 'prev()',
       message: 'Log data key 1',
       text: 'content_type'
     }).appendTo(eventCard);
-    const logValue1 = new tabris.TextInput({
+    let logValue1 = new TextInput({
       id: 'logValue1',
       left: logKey1, right: MARGIN, baseline: logKey1,
       message: 'Log data value 1',
       text: 'news article'
     }).appendTo(eventCard);
 
-    const logKey2 = new tabris.TextInput({
+    let logKey2 = new TextInput({
       left: MARGIN, right: ['#logValue2', MARGIN], top: 'prev()',
       message: 'Log data key 2',
       text: 'item_name'
     }).appendTo(eventCard);
-    const logValue2 = new tabris.TextInput({
+    let logValue2 = new TextInput({
       id: 'logValue2',
       left: logKey2, right: MARGIN, baseline: logKey2,
       message: 'Log data value 2',
@@ -108,16 +112,16 @@ module.exports = class AnalyticsPage extends tabris.Page {
       });
     }).appendTo(eventCard);
 
-    let userPropertiesCard = new Card({title: 'User properties'}).appendTo(scrollView);
+    let userPropertiesCard = this._createCard('User properties').appendTo(scrollView);
 
-    new tabris.TextView({
+    new TextView({
       id: 'userPropertyKeyLabel',
       left: MARGIN, right: ['#userPropertyValueLabel', MARGIN], top: ['prev()', MARGIN],
       text: 'Key',
       font: 'medium 14px',
       textColor: res.color.textInputLabel
     }).appendTo(userPropertiesCard);
-    new tabris.TextView({
+    new TextView({
       id: 'userPropertyValueLabel',
       left: '#userPropertyKeyLabel', right: MARGIN, baseline: '#userPropertyKeyLabel',
       text: 'Value',
@@ -125,12 +129,12 @@ module.exports = class AnalyticsPage extends tabris.Page {
       textColor: res.color.textInputLabel
     }).appendTo(userPropertiesCard);
 
-    const userPropertyKey = new tabris.TextInput({
+    let userPropertyKey = new TextInput({
       left: MARGIN, right: ['#userPropertyValue', MARGIN], top: 'prev()',
       message: 'User property key',
       text: 'priority_customer'
     }).appendTo(userPropertiesCard);
-    const userPropertyValue = new tabris.TextInput({
+    let userPropertyValue = new TextInput({
       id: 'userPropertyValue',
       left: userPropertyKey, right: MARGIN, baseline: userPropertyKey,
       message: 'User property value',
@@ -143,9 +147,9 @@ module.exports = class AnalyticsPage extends tabris.Page {
     }).on('tap', () => firebase.Analytics.setUserProperty(userPropertyKey.text, userPropertyValue.text))
       .appendTo(userPropertiesCard);
 
-    let userIdCard = new Card({title: 'User id'}).appendTo(scrollView);
+    let userIdCard = this._createCard('User id').appendTo(scrollView);
 
-    const userId = new tabris.TextInput({
+    let userId = new TextInput({
       left: MARGIN, right: MARGIN, top: ['prev()', MARGIN_SMALL],
       message: 'User id',
       text: 'anonymous_user_id'
@@ -157,7 +161,14 @@ module.exports = class AnalyticsPage extends tabris.Page {
     }).on('tap', () => firebase.Analytics.userId = userId.text)
       .appendTo(userIdCard);
 
-    new tabris.Composite({top: 'prev()', height: MARGIN}).appendTo(scrollView);
-
+    new Composite({top: 'prev()', height: MARGIN}).appendTo(scrollView);
   }
+
+  _createCard(title) {
+    return new Card({
+      left: MARGIN, right: MARGIN, top: ['prev()', MARGIN],
+      title
+    });
+  }
+
 };

--- a/example/src/pages/messaging.js
+++ b/example/src/pages/messaging.js
@@ -1,3 +1,4 @@
+const {Composite, Page, ScrollView, TextView} = require('tabris');
 const Card = require('../widgets/Card');
 const FlatButton = require('../widgets/FlatButton');
 const res = require('../resources');
@@ -5,52 +6,56 @@ const res = require('../resources');
 const MARGIN = res.dimen.margin;
 const MARGIN_SMALL = res.dimen.marginSmall;
 
-module.exports = class MessagingPage extends tabris.Page {
+module.exports = class MessagingPage extends Page {
 
   constructor(properties) {
-    super(properties);
-    this.title = 'Firebase Cloud Messaging';
-    this.description = 'Use Cloud Messaging to have custom data pushed to your device without a persistent connection.';
-    this.autoDispose = false;
-    this.background = res.color.pageBackground;
-    this.once('appear', this._createPageContent);
+    super(Object.assign({
+      title: 'Firebase Cloud Messaging',
+      autoDispose: false,
+      background: res.color.pageBackground,
+    }, properties));
+    this._createContent();
   }
 
-  _createPageContent({target: page}) {
+  get DESCRIPTION() {
+    return 'Use Cloud Messaging to have custom data pushed to your device without a persistent connection.';
+  }
 
-    const scrollView = new tabris.ScrollView({
+  _createContent() {
+
+    let scrollView = new ScrollView({
       left: 0, right: 0, top: 0, bottom: 0
-    }).appendTo(page);
+    }).appendTo(this);
 
-    let messageCard = new Card({title: 'Cloud Message'}).appendTo(scrollView);
+    let messageCard = this._createCard('Cloud Message').appendTo(scrollView);
 
-    new tabris.TextView({
+    new TextView({
       left: MARGIN, top: ['prev()', MARGIN], right: MARGIN,
       text: 'Use the following token to send messages to this device:'
     }).appendTo(messageCard);
 
-    const tokenText = new tabris.TextView({
+    let tokenText = new TextView({
       left: MARGIN, top: ['prev()', MARGIN], right: MARGIN,
       font: '14px monospace',
       selectable: true
     }).appendTo(messageCard);
 
-    const messageText = new tabris.TextView({
+    let messageText = new TextView({
       left: MARGIN, top: ['prev()', MARGIN], right: MARGIN,
       text: 'Waiting for message...'
     }).appendTo(messageCard);
 
     // composite is a workaround for tabris-android bug where setting bottom would collapse messageText
-    new tabris.Composite({top: 'prev()', height: MARGIN}).appendTo(messageCard);
+    new Composite({top: 'prev()', height: MARGIN}).appendTo(messageCard);
 
-    let instanceIdCard = new Card({title: 'Instance Id'}).appendTo(scrollView);
+    let instanceIdCard = this._createCard('Instance Id').appendTo(scrollView);
 
-    new tabris.TextView({
+    new TextView({
       left: MARGIN, top: ['prev()', MARGIN],
       text: 'Instance id:'
     }).appendTo(instanceIdCard);
 
-    const instanceIdText = new tabris.TextView({
+    let instanceIdText = new TextView({
       left: ['prev()', MARGIN_SMALL], baseline: 'prev()', right: MARGIN,
       selectable: true,
       font: '14px monospace'
@@ -62,7 +67,7 @@ module.exports = class MessagingPage extends tabris.Page {
     }).on('tap', () => firebase.Messaging.resetInstanceId())
       .appendTo(instanceIdCard);
 
-    new tabris.Composite({top: 'prev()', height: MARGIN}).appendTo(scrollView);
+    new Composite({top: 'prev()', height: MARGIN}).appendTo(scrollView);
 
     if (firebase.Messaging.launchData) {
       messageText.text = 'App launched with data:\n\n' + JSON.stringify(firebase.Messaging.launchData);
@@ -77,11 +82,18 @@ module.exports = class MessagingPage extends tabris.Page {
     updateMessagingDetails();
 
     function updateMessagingDetails() {
-      const token = firebase.Messaging.token;
+      let token = firebase.Messaging.token;
       tokenText.text = token ? token : 'Loading token...';
       instanceIdText.text = firebase.Messaging.instanceId;
     }
 
+  }
+
+  _createCard(title) {
+    return new Card({
+      left: MARGIN, right: MARGIN, top: ['prev()', MARGIN],
+      title
+    });
   }
 
 };

--- a/example/src/widgets/Card.js
+++ b/example/src/widgets/Card.js
@@ -1,25 +1,39 @@
+const {Composite, TextView} = require('tabris');
 const res = require('../resources');
 
 const MARGIN = res.dimen.margin;
 
-class Card extends tabris.Composite {
+class Card extends Composite {
+
   constructor(properties = {}) {
-    properties['left'] = MARGIN;
-    properties['right'] = MARGIN;
-    properties['top'] = ['prev()', MARGIN];
-    properties['background'] = 'white';
-    properties['elevation'] = 2;
-    properties['cornerRadius'] = 2;
-    const title = properties.title;
-    delete properties.title;
-    super(properties);
-    new tabris.TextView({
+    super(Object.assign({
+      background: 'white',
+      elevation: 2,
+      cornerRadius: 2
+    }, properties));
+  }
+
+  set title(title) {
+    (this._getTitleLabel() || this._createTitleLabel()).text = title.toUpperCase();
+  }
+
+  get title() {
+    return this._getTitleLabel().text || '';
+  }
+
+  _getTitleLabel() {
+    return this.find('#titleLabel').first();
+  }
+
+  _createTitleLabel() {
+    return new TextView({
+      id: 'titleLabel',
       left: MARGIN, right: MARGIN, top: MARGIN,
-      text: title,
       font: 'medium 16px',
       textColor: res.color.textSecondary
     }).appendTo(this);
   }
+
 }
 
 module.exports = Card;

--- a/example/src/widgets/FlatButton.js
+++ b/example/src/widgets/FlatButton.js
@@ -1,22 +1,39 @@
+const {Composite, TextView} = require('tabris');
 const res = require('../resources');
 
 const HORIZONTAL_MARGIN = 8;
 
-class FlatButton extends tabris.Composite {
+class FlatButton extends Composite {
+
   constructor(properties = {}) {
-    properties['cornerRadius'] = 2;
-    properties['background'] = properties['background'] === undefined ? 'white' : properties['background'];
-    properties['highlightOnTouch'] = true;
-    const text = properties.text;
-    delete properties.text;
-    super(properties);
-    new tabris.TextView({
+    super(Object.assign({
+      cornerRadius: 2,
+      background: 'white',
+      highlightOnTouch: true
+    }, properties));
+  }
+
+  set text(text) {
+    (this._getTextLabel() || this._createTextLabel()).text = text.toUpperCase();
+  }
+
+  get text() {
+    return this._getTextLabel().text || '';
+  }
+
+  _getTextLabel() {
+    return this.find('#textLabel').first();
+  }
+
+  _createTextLabel() {
+    return new TextView({
+      id: 'textLabel',
       left: HORIZONTAL_MARGIN, right: HORIZONTAL_MARGIN, height: 48,
-      text: text.toUpperCase(),
       font: 'medium 14px',
       textColor: res.color.accent
     }).appendTo(this);
   }
+
 }
 
 module.exports = FlatButton;


### PR DESCRIPTION
Apply common EclipseSource Tabris.js app conventions and practices to
the example app.

- use let instead of const consistently according to the convention used
  in other EclipseSource Tabris.js apps (only use "const" for
  primitives)
- destructure required tabris module to prevent using the global tabris
  variable and make code easier to read
- use capital case for static class variables to better distinguish them
  from widget properties
- don't modify the input properties object using Object.assign() instead
- use real properties for custom widget configurations not supported by
  the base widget
- let the consumer configure custom widget layout, since it should not
  be configured by the custom widget itself

Change-Id: I72a5481c417e952e2a4007ef3c006f1a255991d7