### PR TITLE
Update project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ The `tabris-plugin-firebase` plugin provides a [Tabris.js](https://tabrisjs.com)
 
 ## Integrating the plugin
 
-Using the plugin follows the standard cordova plugin mechanism. The Tabris.js website provides detailed information on how to [integrate custom plugins](https://tabrisjs.com/documentation/latest/build#adding-plugins) in your Tabris.js app.
+The Tabris.js website provides detailed information on how to [integrate custom plugins](https://tabrisjs.com/documentation/latest/build#adding-plugins) in your Tabris.js app.
 
 ### Add the plugin to your project
 
 The plugin should be added as an entry in the apps `config.xml` file:
 
 ```xml
-<plugin name="tabris-plugin-firebase" spec="1.0.0" /> 
+<plugin name="tabris-plugin-firebase" spec="1.0.0" />
 ```
 
 To fetch the latest development version use the GitHub url:

--- a/doc/cloud-messaging.md
+++ b/doc/cloud-messaging.md
@@ -21,7 +21,7 @@ firebase.Messaging.on('message',
 console.log('Message data from app cold start: ' + firebase.Messaging.launchData);
 ```
 
-A more elaborate example can be found in the [example](../example/) folder. It provides a Tabris.js cordova project that demonstrates the various features of the `tabris-plugin-firebase` integration. When building the example project make sure to run `npm install` inside its `www` folder to fetch the Tabris.js dependencies.
+A more elaborate example can be found in the [example](../example/) folder. It provides a Tabris.js app that demonstrates the various features of the `tabris-plugin-firebase` integration.
 
 To [send a message](https://firebase.google.com/docs/cloud-messaging/send-message) from the server side a `curl` command similar to the following `POST` request can be used:
 
@@ -47,12 +47,6 @@ The icon can be configured inside your apps `config.xml`:
 <plugin name="tabris-plugin-firebase" spec="1.0.0">
   <variable name="ANDROID_NOTIFICATION_ICON" value="@drawable/ic_notification" />
 </plugin>
-```
-
-Alternatively the image can be added during the `cordova plugin add` command:
-
-```bash
-cordova plugin add <path-to-tabris-firebase-plugin> --variable ANDROID_NOTIFICATION_ICON=`icon_drawable_name`
 ```
 
 When no notification icon is specified, the outline of the app icon is used.

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. To run the example it is recommended to use the [tabris-cli](https://www.npmjs.com/package/tabris-cli). The tabris-cli requires a local [Tabris.js platform](https://tabrisjs.com/download) which should be referenced by a corresponding environment variable.
+1. To run the example it is recommended to use the [Tabris.js CLI](https://www.npmjs.com/package/tabris-cli).
 
 2. For Android place your `google-services.json` file in the root directory of the example project.
 
@@ -16,7 +16,7 @@
 
 ## Running the Example
 
-Using the tabris-cli the example can be started via
+Using the Tabris.js CLI the example can be started via
 
 ```sh
 $ tabris run <platform>


### PR DESCRIPTION
Align documentation with the state of Tabris.js 2.0.0.

* Reduce references to Cordova, since Tabris.js CLI encapsulates it.
* Remove recommendation to run "npm install" in the example project,
  since "tabris run" does this already.
* Use the term "Tabris.js CLI" instead of "tabris-cli" consistently.
* Remove documentation for configuring the custom notification icon
  using the cordova --variables parameter. This feature is not supported
  by the Tabris.js CLI anyway and in the long term one should store this
  configuration in config.xml anyway.
