### PR TITLE
Update .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,13 @@ project/
 .gitignore
 .eslintrc
 .github
+.DS_Store
+.gradle/
+.history/
+build/
+node_modules/
+platforms/
+plugins/
+*.iml
+local.properties
+npm-debug.log*


### PR DESCRIPTION
When .npmignore and .gitignore are both present and .gitignore includes
files not listed in .npmignore, they will be included in the package.
Add all entries from .gitignore to which should not be included in the
built npm package to .npmignore.

Change-Id: Ib66f4d5dcc3ad23aac3a65855828db5455c2bce2