### PR TITLE
Improve misleading error message

### DIFF
--- a/scripts/android/copy_google_services.js
+++ b/scripts/android/copy_google_services.js
@@ -7,7 +7,7 @@ const GOOGLE_SERVICES_JSON = 'google-services.json';
 
 if (!fs.existsSync(GOOGLE_SERVICES_JSON)) {
   throw new Error(
-    'No "google-services.json" file found in project root directory. ' +
+    'No "google-services.json" file found in /cordova.' +
     'Required by plugin "tabris-plugin-firebase" (Android).');
 } else {
   if (fs.existsSync(ANDROID_PLATFORM) && fs.statSync(ANDROID_PLATFORM).isDirectory()) {


### PR DESCRIPTION
The error message shown when the google-services.json file is not found 
is misleading, since the file should be located in an app subdirectory named
/cordova and not in its root.

Since Tabris.js 2.x stable, Cordova-based project layout is not supported 
anymore. Cordova artifacts will be placed in a /cordova subdirectory in the
root of the app and "context.opts.projectRoot" refered to in scripts will
resolve with its path.