### PR TITLE
Fix example resources not available on Android

### DIFF
--- a/example/cordova/config.xml
+++ b/example/cordova/config.xml
@@ -13,7 +13,7 @@
   </plugin>
 
   <platform name="android">
-    <hook type="after_platform_add" src="scripts/android/copy-resources.js" />
+    <hook type="after_prepare" src="scripts/android/copy-resources.js" />
     <preference name="Theme" value="@style/Theme.Firebase" />
   </platform>
 

--- a/example/cordova/scripts/android/copy-resources.js
+++ b/example/cordova/scripts/android/copy-resources.js
@@ -20,6 +20,6 @@ function copyRecursiveSync(src, dest) {
     fs.readdirSync(src)
       .forEach(childItemName => copyRecursiveSync(path.join(src, childItemName), path.join(dest, childItemName)));
   } else {
-    fs.linkSync(src, dest);
+    fs.writeFileSync(dest, fs.readFileSync(src));
   }
 }


### PR DESCRIPTION
Due to Cordova issue 10654 [1] the after_platform_add hook did not get
executed. Use the after_prepare hook instead, which is called when the
native SDK project stands in place.

Change the copy-resources script to actually copy the resources instead of
linking them. Its name was misleading. Moreover, this is required since
after_prepare may get executed multiple times when building with the
Tabris.js CLI (once after platform add and once on build/run) -
overwriting links is not possible using fs.link() and fs.writeFileSync()
overwrites existing files per default.

[1]: https://issues.apache.org/jira/browse/CB-10654

Change-Id: I787161816da338fcfb7c79876329950e3451023e