### PR TITLE
Update supported Tabris version to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Tabris.js website provides detailed information on how to [integrate custom 
 The plugin should be added as an entry in the apps `config.xml` file:
 
 ```xml
-<plugin name="tabris-plugin-firebase" spec="1.0.0" />
+<plugin name="tabris-plugin-firebase" spec="^1.0.0" />
 ```
 
 To fetch the latest development version use the GitHub url:
@@ -54,7 +54,7 @@ Feature | Supported platforms
 
 ## Compatibility
 
-Compatible with [Tabris.js 2.0.0](https://github.com/eclipsesource/tabris-js/releases/tag/v2.0.0)
+Compatible with [Tabris.js 2.x](https://github.com/eclipsesource/tabris-js/releases/)
 
 ## Plugin development
 

--- a/doc/cloud-messaging.md
+++ b/doc/cloud-messaging.md
@@ -44,7 +44,7 @@ An Android [notification icon](https://developer.android.com/guide/practices/ui_
 The icon can be configured inside your apps `config.xml`:
 
 ```xml
-<plugin name="tabris-plugin-firebase" spec="1.0.0">
+<plugin name="tabris-plugin-firebase" spec="^1.0.0">
   <variable name="ANDROID_NOTIFICATION_ICON" value="@drawable/ic_notification" />
 </plugin>
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -3,6 +3,6 @@
   "description": "Example for the Tabris firebase plugin.",
   "main": "src/app.js",
   "dependencies": {
-    "tabris": "2.0.0"
+    "tabris": "^2.0.0"
   }
 }


### PR DESCRIPTION
Since custom widget API is final now, it should not break between minor
version updates of Tabris.js.

Use carret version syntax for the Cordova plugin as this is the default
semver specifier used by npm. This will provide non-breaking
improvements to the plugin and prevent having to update the version in
the README on each patch version update.