### PR TITLE
Update and bundle type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "tabris-plugin-firebase",
   "version": "2.0.0",
   "description": "A firebase plugin for Tabris.js",
+  "types": "./types/index.d.ts",
+  "peerDependencies": {
+    "tabris": "~2.5.1"
+  },
   "cordova": {
     "id": "tabris-plugin-firebase",
     "platforms": [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,52 @@
+import { EventObject, Widget, WidgetEvents, WidgetProperties, NativeObject, PropertyChangedEvent } from 'tabris';
+
+declare global {
+  namespace firebase {
+    const Analytics: Analytics;
+    const Messaging: Messaging;
+    const MessagingEvents: MessagingEvents;
+    const MessageEvent: MessageEvent;
+    type AnalyticsProperties = Partial<PropertyMixins.Analytics>;
+
+    interface Analytics extends NativeObject, PropertyMixins.Analytics {
+      logEvent(eventName: string, parameters?: { [key: string]: string }): void;
+      setUserProperty(propertyName: string, value: string): void;
+      set(properties: AnalyticsProperties): this;
+      set(property: string, value: any): this;
+    }
+
+    interface Messaging extends NativeObject {
+      readonly instanceId: string;
+      readonly token: string;
+      readonly launchData: object;
+      resetInstanceId(): void;
+      requestPermissions(): void;
+      on(type: string, listener: (event: any) => void, context?: object): this;
+      on(listeners: MessagingEvents): this;
+      off(type: string, listener: (event: any) => void, context?: object): this;
+      off(listeners: MessagingEvents): this;
+      once(type: string, listener: (event: any) => void, context?: object): this;
+      once(listeners: MessagingEvents): this;
+    }
+
+    interface MessagingEvents {
+      instanceIdChanged?(event: PropertyChangedEvent<Messaging, string>): void;
+      tokenChanged?(event: PropertyChangedEvent<Messaging, string>): void;
+      message?(event: MessageEvent): void;
+    }
+
+    interface MessageEvent extends EventObject<Messaging> {
+      data: any;
+    }
+
+    namespace PropertyMixins {
+      interface Analytics {
+        analyticsCollectionEnabled: boolean;
+        screenName: string;
+        userId: string;
+      }
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
Analogically to tabris-plugin-barcode-scanner, bundle the type
definitions in the app. Migrated and updated
"@types/tabris-plugin-firebase" to include the newly introduced
"requestPermissions()" method.

Removal of the "@types/tabris-plugin-firebase" package to be requested
[1] after the new plugin version has been released.

[1]: https://github.com/DefinitelyTyped/DefinitelyTyped#removing-a-package

Change-Id: I017cbc00e5aa8937e946a677701f79e879933759