### PR TITLE
Fix broken AppDelegate after injecting the sources

### DIFF
--- a/scripts/ios/custom-widget.js
+++ b/scripts/ios/custom-widget.js
@@ -19,6 +19,17 @@ if (rootdir) {
       return path.join(projectRoot, "platforms", platform, cfg.name(), relPath);
     };
 
+    var appendTo = function(path, methodHeader, implementation) {
+      var data = fs.readFileSync(path, "utf8");
+      var indexOfMethodHeader = data.indexOf(methodHeader);
+      if (indexOfMethodHeader == -1) {
+        return false;        
+      }
+      var result = data.replace(methodHeader, methodHeader + '\n' + implementation);
+      fs.writeFileSync(path, result, "utf8");
+      return true;
+    };
+
     var replace = function(path, to_replace, replace_with) {
       var data = fs.readFileSync(path, "utf8");
       var result = data.replace(to_replace, replace_with);
@@ -31,7 +42,14 @@ if (rootdir) {
       var finishLaunchingReplace = "/* HOOK: applicationDidFinishLaunching */";
       replace(appDelegate, importReplace, "#import \"ESFBMessaging.h\"\n" + importReplace);
       replace(appDelegate, finishLaunchingReplace, "[ESFBMessaging setLaunchData:launchOptions];\n\t" + finishLaunchingReplace);
-      replace(appDelegate, "@end", "- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler {" + "\n\t" + "[ESFBMessaging notificationReceived:userInfo];" + "\n\t" + "completionHandler(UIBackgroundFetchResultNewData);\n}" + "\n\n" + "@end")
+
+
+      var header = "- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler {";
+      var implementation = "\t[ESFBMessaging notificationReceived:userInfo];" + "\n\t" + "completionHandler(UIBackgroundFetchResultNewData);\n";
+      var method = header + "\n" + "\t[ESFBMessaging notificationReceived:userInfo];\n" + '}';
+      if (!appendTo(appDelegate, header, implementation)) {
+        replace(appDelegate, "@end", method + "\n" + "@end");
+      }
     };
 
     updateIOSAppDelegate();


### PR DESCRIPTION
It's possible that methods implemented by this plugin are already
implemented in AppDelegate.m file. Using the script with its current
state leads to a compile-time error:
"Duplicate implementation for a method: xxx"

We have to check first if the method is implemented, and if it is then
we inject the new code to the existing implementation. If it's not then
we just put in the whole method. Like we did before.
