### PR TITLE
[JS] Implement pendingMessages

### DIFF
--- a/doc/cloud-messaging.md
+++ b/doc/cloud-messaging.md
@@ -39,8 +39,8 @@ curl -X POST -H "Authorization: key=<server-key>" -H "Content-Type: application/
 
 ### Custom notification icon (optional)
 
-An Android [notification icon](https://developer.android.com/guide/practices/ui_guidelines/icon_design_status_bar.html) can be provided via the plugin variable `ANDROID_NOTIFICATION_ICON`. To configure a notification icon a 
-resource id of an Android drawable can be specified. The `<resource-file />` cordova directive can be used to copy the file into the Android folder `app/src/main/res/`. See the [example 
+An Android [notification icon](https://developer.android.com/guide/practices/ui_guidelines/icon_design_status_bar.html) can be provided via the plugin variable `ANDROID_NOTIFICATION_ICON`. To configure a notification icon a
+resource id of an Android drawable can be specified. The `<resource-file />` cordova directive can be used to copy the file into the Android folder `app/src/main/res/`. See the [example
  config.xml](../example/cordova/config.xml) for a snippet to get you started.
 
 The icon can be configured inside your apps `config.xml`:
@@ -107,6 +107,18 @@ All `Messaging` properties are read only.
 ##### `instanceId` : _string_
 
 * A stable identifier that uniquely identifies the app installation. Note that on Android the instance id can become invalid as noted in the [documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html).
+
+##### `pendingMessages` : _{ getAll(), clearAll() }_
+
+* Represents messages provided by the system notification manager, which have arrived while the app hasn't been in the foreground and have not been consumed yet.
+
+###### `getAll()` (iOS-only) : _object[]_
+
+* Returns an array with all pending messages.
+
+###### `clearAll()` (iOS-only)
+
+* Clears all pending messages.
 
 ##### `token` : _string_
 

--- a/example/src/pages/messaging.js
+++ b/example/src/pages/messaging.js
@@ -73,6 +73,16 @@ module.exports = class MessagingPage extends Page {
         text: 'Request permissions'
       }).on('tap', () => firebase.Messaging.requestPermissions())
         .appendTo(scrollView);
+      new Button({
+        top: ['prev()', MARGIN_SMALL], centerX: 0,
+        text: 'Print all pending messages'
+      }).on('tap', () => console.log(firebase.Messaging.pendingMessages.getAll()))
+        .appendTo(scrollView);
+      new Button({
+        top: ['prev()', MARGIN_SMALL], centerX: 0,
+        text: 'Clear all pending messages'
+      }).on('tap', () => console.log(firebase.Messaging.pendingMessages.clearAll()))
+        .appendTo(scrollView);
     }
 
     new Composite({top: 'prev()', height: MARGIN}).appendTo(scrollView);

--- a/www/Messaging.js
+++ b/www/Messaging.js
@@ -34,6 +34,15 @@ Messaging.prototype.requestPermissions = function() {
   return this;
 }
 
+Object.defineProperty(Messaging.prototype, 'pendingMessages', {
+  get: function() {
+    return {
+      getAll: () => this._nativeCall('getAll') || [],
+      clearAll: () => this._nativeCall('clearAll')
+    }
+  }
+});
+
 tabris.NativeObject.defineProperties(Messaging.prototype, {
   instanceId: {type: 'string', nocache: true, access: readOnly},
   token: {type: 'string', nocache: true, access: readOnly},


### PR DESCRIPTION
Since they are only supported on iOS 10+, use lambda functions for
convenience when defining the "pendingMessages" namespace.

See #46

Change-Id: Ibb8f69cb8de53b5af14811983f551a639bfddd8f