### PR TITLE
Support integration with the Google Tag Manager

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,7 @@
     <clobbers target="firebase.Analytics" />
   </js-module>
 
+  <hook src="scripts/copy_tagmanager_containers.js" type="after_plugin_install" />
 
   <platform name="android">
 
@@ -71,6 +72,15 @@
     <framework src="com.google.firebase:firebase-core:12.0.1" />
     <framework src="com.google.firebase:firebase-messaging:12.0.1" />
     <framework src="com.google.firebase:firebase-analytics:12.0.1" />
+    <framework src="com.google.android.gms:play-services-tagmanager:12.0.1" />
+    <config-file target="AndroidManifest.xml" parent="/manifest/application">
+      <service android:name="com.google.android.gms.analytics.AnalyticsService" android:enabled="true" android:exported="false" />
+      <receiver android:name="com.google.android.gms.analytics.AnalyticsReceiver" android:enabled="true">
+        <intent-filter>
+          <action android:name="com.google.android.gms.analytics.ANALYTICS_DISPATCH" />
+        </intent-filter>
+      </receiver>
+    </config-file>
 
     <source-file src="src/android/com/eclipsesource/firebase/messaging/MessagingOperator.kt"
                  target-dir="src/com/eclipsesource/firebase/messaging" />
@@ -125,6 +135,7 @@
     <!-- Frameworks -->
     <framework src="FirebaseAnalytics" type="podspec" spec="~> 4.2.0"/>
     <framework src="FirebaseMessaging" type="podspec" spec="~> 2.2.0"/>
+    <framework src="GoogleTagManager" type="podspec" spec="~> 6.0.0"/>
 
     <!-- Sources -->
     <!-- Analytics -->

--- a/scripts/android/copy_google_services.js
+++ b/scripts/android/copy_google_services.js
@@ -7,7 +7,7 @@ const GOOGLE_SERVICES_JSON = 'google-services.json';
 
 if (!fs.existsSync(GOOGLE_SERVICES_JSON)) {
   throw new Error(
-    'No "google-services.json" file found in /cordova.' +
+    'No "google-services.json" file found in /cordova. \n' +
     'Required by plugin "tabris-plugin-firebase" (Android).');
 } else {
   if (fs.existsSync(ANDROID_PLATFORM) && fs.statSync(ANDROID_PLATFORM).isDirectory()) {

--- a/scripts/copy_tagmanager_containers.js
+++ b/scripts/copy_tagmanager_containers.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ANDROID_PLATFORM = 'platforms/android';
+const IOS_PLATFORM = 'platforms/ios';
+
+module.exports = function(ctx) {
+  let platform = ctx.opts.cordova.platforms[0];
+  let containerSourceDir = platform === 'android' ? path.join('tagmanager-container', 'android') : path.join('tagmanager-container', 'ios');
+  let containerTargetDir = platform === 'android' ? path.join(ANDROID_PLATFORM, 'assets', 'containers') : path.join(IOS_PLATFORM, 'container');
+  if (!fs.existsSync(containerSourceDir) || !fs.readdirSync(containerSourceDir).length) {
+    throw new Error(
+      `No containers found in /cordova/${containerSourceDir}. \n` +
+      `Required by plugin "${ctx.opts.plugin.id}" with enabled "tagmanager" feature.`);
+  }
+  let files = fs.readdirSync(containerSourceDir);
+  let containerFileName = path.basename(files.filter(file => file.match(/json$/))[0]);
+  if (!fs.existsSync(containerTargetDir)) {
+    fs.mkdirSync(containerTargetDir);
+  }
+  let source = path.join(containerSourceDir, containerFileName);
+  let target = path.join(containerTargetDir, containerFileName);
+  fs.writeFileSync(target, fs.readFileSync(source, 'utf-8'));
+  if (platform === 'ios') {
+    addContainerResourceToPbxProject(ctx, containerFileName);
+  }
+}
+
+function addContainerResourceToPbxProject(context) {
+  let xcode = context.requireCordovaModule('xcode');
+  let fileList = fs.readdirSync(IOS_PLATFORM);
+  let xcodeProjectDirectory = fileList.find(file => file.match(/xcodeproj$/));
+  let xcodeProjectFilePath = path.join(IOS_PLATFORM, xcodeProjectDirectory, 'project.pbxproj');
+  let xcodeProject = xcode.project(xcodeProjectFilePath);
+  xcodeProject.parseSync();
+  // See https://github.com/apache/cordova-ios/blob/4.5.x/bin/templates/project/__TEMP__.xcodeproj/project.pbxproj#L95
+  const CUSTOM_TEMPLATE_PBX_GROUP = '29B97314FDCFA39411CA2CEA';
+  xcodeProject.addResourceFile(`container`, {}, CUSTOM_TEMPLATE_PBX_GROUP);
+  fs.writeFileSync(xcodeProjectFilePath, xcodeProject.writeSync());
+}


### PR DESCRIPTION
Let containers reside in directories called
tagmanager-container/{{platform}} in order for the plugin to be agnostic
about the naming scheme of the container.

Change-Id: Ia076d5c5787993319146c97be8db956804a185e2