### PR TITLE
Prevent notification messages

### DIFF
--- a/src/android/com/eclipsesource/firebase/messaging/MessagingHandler.kt
+++ b/src/android/com/eclipsesource/firebase/messaging/MessagingHandler.kt
@@ -26,7 +26,9 @@ class MessagingHandler(private val scope: ActivityScope) : ObjectHandler<Messagi
     }
 
   override fun destroy(nativeObject: Messaging) {
-    messaging = null
+    if (nativeObject == messaging) {
+      messaging = null
+    }
   }
 
   companion object {


### PR DESCRIPTION
The plugin receives a data message as a notification, even when the app is in the foreground. The issue occurs after the first reload of the application.

When we reload the app, unlike previous versions, the first new components are created, and then old components are destroyed in the latest tabris android platform. As a result, the static messaging variable is set to null by the old MessagingHandler, which is destroyed at the end.

The change prevents static messaging from being updated by old handlers.