### PR TITLE
Fix 'plugin with id not found' error

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,3 +1,19 @@
+import com.google.gms.googleservices.GoogleServicesPlugin
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.google.gms:google-services:4.3.3'
+    }
+}
+
 ext.postBuildExtras = {
-    apply plugin: 'com.google.gms.google-services'
+    if (project.extensions.findByName('googleServices') == null) {
+        apply plugin: GoogleServicesPlugin
+    }
 }


### PR DESCRIPTION
When we build a Tabris.js app with the 'tabris-plugin-firebase' plugin, the build fails with the error "Plugin with id 'com.google.gms.google-services' not found.".

The change uses the class name GoogleServicesPlugin instead of id(string) to be able to apply the plugin from the non-root gradle file, which solves the issue. Additionally, the change applies the plugin if the `googleServices` is not added to `cdvPluginPostBuildExtras` somewhere else.

Fixes #71