### PR TITLE
Improve management of messaging in MessagingHandler

### DIFF
--- a/src/android/com/eclipsesource/firebase/messaging/MessagingHandler.kt
+++ b/src/android/com/eclipsesource/firebase/messaging/MessagingHandler.kt
@@ -27,20 +27,25 @@ class MessagingHandler(private val scope: ActivityScope) : ObjectHandler<Messagi
 
   override fun destroy(nativeObject: Messaging) {
     if (nativeObject == messaging) {
-      messaging = null
+      resetMessaging()
     }
   }
 
   companion object {
 
-    var messaging: Messaging? = null
-      set(value) {
-        if (value == null || field == null) {
-          field = value
-        } else {
-          throw IllegalStateException("Messaging object has already been created.")
-        }
+    private var messaging: Messaging? = null
+
+    fun setMessaging(value: Messaging) {
+      if (messaging == null) {
+        messaging = value
+      } else {
+        throw IllegalStateException("Messaging object has already been created.")
       }
+    }
+
+    fun resetMessaging() {
+      messaging = null
+    }
 
     fun tokenReceived(token: String) = messaging?.onTokenReceived(token)
 


### PR DESCRIPTION
When we sideload an app, the constructor of Messaging updates the static variable `MessagingHandler.messaging`, which throws the IllegalStateException when its value is not null. As a result, the app crashes due to the uncaught exception.

The change introduces the following changes:
* Updates the access modifier of the static `MessagingHandler.messaging` to private, which only updates its value through functions.
* Resets the static variable `MessagingHandler.messaging` in the Messaging constructor.
* Catches the excpetion and prints it to the console when updating the `MessagingHandler.messaging` throws an exception.