### PR TITLE
Remove `instanceId` from `Messaging` object

### DIFF
--- a/doc/cloud-messaging.md
+++ b/doc/cloud-messaging.md
@@ -73,10 +73,6 @@ The firebase messaging API is represented as the global object `firebase.Messagi
 
 All `Messaging` properties are read only.
 
-##### `instanceId` : _string_
-
-* A stable identifier that uniquely identifies the app installation. Note that on Android the instance id can become invalid as noted in the [documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html).
-
 ##### `pendingMessages` : _{ getAll(), clearAll() }_
 
 * Represents messages provided by the system notification manager, which have arrived while the app hasn't been in the foreground and have not been consumed yet.
@@ -91,7 +87,7 @@ All `Messaging` properties are read only.
 
 ##### `token` : _string_
 
-* A registration `token` to be used on the server side to address an app installation. The registration `token` is usually available but can change during the apps lifetime. To get notified of a registration token updates you should listen for `tokenChanged` events. When resetting the `instanceId`, the token is not available until the `tokenChanged` event fired.
+* A registration `token` to be used on the server side to address an app installation. The registration `token` is usually available but can change during the apps lifetime. To get notified of a registration token updates you should listen for `tokenChanged` events.
 
 ##### `launchData` : _object_
 
@@ -102,17 +98,6 @@ All `Messaging` properties are read only.
 * The recommended way to make sure your app receives all messaging data is to check the `firebase.Messaging.launchData` object on app startup and to register for the `message` event to receive follow-up messages.
 
 #### Events
-
-##### `instanceIdChanged`
-
-* The `instanceIdChanged` event is fired asynchronously when the `resetInstanceId()` method is invoked.
-
-###### Event Parameters:
-
-* `target` : _Messaging_
-  * The `Messaging` object which allows to interact with firebase cloud messaging
-* `instanceId` : _string_
-  * The new `instanceId` of the app
 
 ##### `tokenChanged`
 
@@ -137,10 +122,6 @@ All `Messaging` properties are read only.
   * The message `data` object as send from the server side
 
 #### Methods
-
-##### `resetInstanceId()`
-
-* Invalidates the current `instanceId` and creates a new one asynchronously. To be notified when a new `instanceId` is available you should listen for the `instanceIdChanged` event. Resetting the `instanceId` also resets the associated registration `token`. A `tokenChanged` event will be fired once a new token is available.
 
 ##### `requestPermissions()` (iOS-only)
 

--- a/example/cordova/config.xml
+++ b/example/cordova/config.xml
@@ -27,5 +27,4 @@
   <platform name="ios">
     <resource-file src="GoogleService-Info.plist" />
   </platform>
-  <hook type="before_platform_add" src="www/app/scripts/add-plugin-from-parent-directory.sh" />
 </widget>

--- a/example/sendTestNotification/index.js
+++ b/example/sendTestNotification/index.js
@@ -4,7 +4,7 @@
   const fetch = require('node-fetch');
 
   if (!fs.existsSync('./service-account-private-key.json')) {
-    throw new Error('Place your service account key in ./scripts/service-account-private-key.json. It can be generated on https://console.cloud.google.com/iam-admin/serviceaccounts for your project.\n\nMake sure that the service account has the permission "cloudmessaging.messages.create". It can be configured here: https://console.cloud.google.com/projectselector2/iam-admin/iam');
+    throw new Error('Place your service account key in ./service-account-private-key.json. It can be generated on https://console.cloud.google.com/iam-admin/serviceaccounts for your project.\n\nMake sure that the service account has the permission "cloudmessaging.messages.create". It can be configured here: https://console.cloud.google.com/projectselector2/iam-admin/iam');
   }
 
   if (!process.env.TABRIS_PLUGIN_FIREBASE_EXAMPLE_FCM_TOKEN) {

--- a/example/src/pages/messaging.js
+++ b/example/src/pages/messaging.js
@@ -48,25 +48,6 @@ module.exports = class MessagingPage extends Page {
     // composite is a workaround for tabris-android bug where setting bottom would collapse messageText
     new Composite({top: 'prev()', height: MARGIN}).appendTo(messageCard);
 
-    let instanceIdCard = this._createCard('Instance Id').appendTo(scrollView);
-
-    new TextView({
-      left: MARGIN, top: ['prev()', MARGIN],
-      text: 'Instance id:'
-    }).appendTo(instanceIdCard);
-
-    let instanceIdText = new TextView({
-      left: ['prev()', MARGIN_SMALL], baseline: 'prev()', right: MARGIN,
-      selectable: true,
-      font: '14px monospace'
-    }).appendTo(instanceIdCard);
-
-    new FlatButton({
-      right: MARGIN, top: ['prev()', MARGIN_SMALL], bottom: MARGIN_SMALL,
-      text: 'Reset instance id'
-    }).on('tap', () => firebase.Messaging.resetInstanceId())
-      .appendTo(instanceIdCard);
-
     if (device.platform === 'iOS') {
       new Button({
         top: ['prev()', MARGIN_SMALL], centerX: 0,
@@ -93,7 +74,6 @@ module.exports = class MessagingPage extends Page {
     }
 
     firebase.Messaging.on({
-      instanceIdChanged: updateMessagingDetails,
       tokenChanged: updateMessagingDetails,
       message: ({data}) => messageText.text = `Message received:\n\n${JSON.stringify(data)}`
     });
@@ -103,7 +83,6 @@ module.exports = class MessagingPage extends Page {
     function updateMessagingDetails() {
       let token = firebase.Messaging.token;
       tokenText.text = token ? token : 'Loading token...';
-      instanceIdText.text = firebase.Messaging.instanceId;
     }
 
   }

--- a/src/ios/src/ESFBMessaging.h
+++ b/src/ios/src/ESFBMessaging.h
@@ -9,12 +9,10 @@
 #import <Tabris/BasicWidget.h>
 
 @interface ESFBMessaging : BasicWidget
-@property (strong, readonly) NSString *instanceId;
 @property (strong, readonly) NSString *token;
 @property (strong, readonly) NSDictionary *launchData;
 @property (assign) BOOL showBannersInForeground;
 @property (assign) BOOL tokenChangedListener;
-@property (assign) BOOL instanceIdChangedListener;
 @property (assign) BOOL messageListener;
 - (void)registerForNotifications;
 + (void)setLaunchData:(NSDictionary *)launchOptions;

--- a/src/ios/src/ESFBMessaging.m
+++ b/src/ios/src/ESFBMessaging.m
@@ -12,16 +12,13 @@
 #import "ESFirebaseHelper.h"
 
 @interface ESFBMessaging () <UNUserNotificationCenterDelegate, FIRMessagingDelegate>
-@property (strong, readwrite) NSString *instanceId;
 @end
 
 @implementation ESFBMessaging
 
-@synthesize instanceId = _instanceId;
 @synthesize token = _token;
 @synthesize launchData = _launchData;
 @synthesize tokenChangedListener = _tokenChangedListener;
-@synthesize instanceIdChangedListener = _instanceIdChangedListener;
 @synthesize messageListener = _messageListener;
 @synthesize showBannersInForeground = _showBannersInForeground;
 
@@ -33,17 +30,9 @@ static NSDictionary *launchData;
     if (self) {
         [UNUserNotificationCenter currentNotificationCenter].delegate = self;
         [FIRMessaging messaging].delegate = self;
-        [self registerSelector:@selector(resetInstanceId) forCall:@"resetInstanceId"];
         [self registerSelector:@selector(registerForNotifications) forCall:@"requestPermissions"];
         [self registerSelector:@selector(getAllPendingMessages) forCall:@"getAllPendingMessages"];
         [self registerSelector:@selector(clearAllPendingMessages) forCall:@"clearAllPendingMessages"];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(instanceIdRefreshed:) name:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
-        __weak ESFBMessaging *weakSelf = self;
-        [[FIRMessaging messaging] tokenWithCompletion:^(NSString * _Nullable token, NSError * _Nullable error) {
-            if(!error) {
-                weakSelf.instanceId = token;
-            }
-        }];
     }
     return self;
 }
@@ -55,11 +44,9 @@ static NSDictionary *launchData;
 
 + (NSMutableSet *)remoteObjectProperties {
     NSMutableSet *properties = [super remoteObjectProperties];
-    [properties addObject:@"instanceId"];
     [properties addObject:@"token"];
     [properties addObject:@"launchData"];
     [properties addObject:@"tokenChangedListener"];
-    [properties addObject:@"instanceIdChangedListener"];
     [properties addObject:@"messageListener"];
     [properties addObject:@"showBannersInForeground"];
     return properties;
@@ -117,10 +104,6 @@ static NSDictionary *launchData;
     [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 
-- (void)resetInstanceId {
-    [[FIRMessaging messaging] deleteTokenWithCompletion:^(NSError * _Nullable error) {}];
-}
-
 - (void)sendMessage:(NSDictionary *)data {
     if (self.messageListener) {
         [self fireEventNamed:@"message" withAttributes:@{@"data":data}];
@@ -150,15 +133,6 @@ static NSDictionary *launchData;
 - (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken {
     if (self.tokenChangedListener) {
         [self fireEventNamed:@"tokenChanged" withAttributes:@{@"token":fcmToken ? fcmToken : [NSNull null]}];
-    }
-}
-
-- (void)instanceIdRefreshed:(NSNotification *)notification {
-    if (self.instanceIdChangedListener) {
-        NSDictionary* attributes = self.instanceId ?
-                                    @{@"instanceId":self.instanceId} : @{};
-        [self fireEventNamed:@"instanceIdChanged"
-              withAttributes:attributes];
     }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,14 +16,12 @@ declare global {
     }
 
     interface Messaging extends NativeObject {
-      readonly instanceId: string;
       readonly token: string;
       readonly launchData: object;
       readonly pendingMessages: {
         getAll: () => object[],
         clearAll: () => void
       };
-      resetInstanceId(): void;
       requestPermissions(): void;
       on(type: string, listener: (event: any) => void, context?: object): this;
       on(listeners: MessagingEvents): this;
@@ -34,7 +32,6 @@ declare global {
     }
 
     interface MessagingEvents {
-      instanceIdChanged?(event: PropertyChangedEvent<Messaging, string>): void;
       tokenChanged?(event: PropertyChangedEvent<Messaging, string>): void;
       message?(event: MessageEvent): void;
     }

--- a/www/Messaging.js
+++ b/www/Messaging.js
@@ -1,4 +1,4 @@
-const EVENT_TYPES = ['tokenChanged', 'instanceIdChanged', 'message'];
+const EVENT_TYPES = ['tokenChanged', 'message'];
 
 const Messaging = tabris.NativeObject.extend('com.eclipsesource.firebase.Messaging');
 
@@ -12,11 +12,6 @@ Messaging.prototype._listen = function(name, listening) {
 
 Messaging.prototype._dispose = function() {
   throw new Error('Messaging can not be disposed');
-};
-
-Messaging.prototype.resetInstanceId = function() {
-  this._nativeCall('resetInstanceId');
-  return this;
 };
 
 Messaging.prototype.requestPermissions = function() {
@@ -38,7 +33,6 @@ Object.defineProperty(Messaging.prototype, 'pendingMessages', {
 });
 
 tabris.NativeObject.defineProperties(Messaging.prototype, {
-  instanceId: {type: 'string', nocache: true, readonly: true},
   token: {type: 'string', nocache: true, readonly: true},
   launchData: {type: 'string', nocache: true, readonly: true}
 });


### PR DESCRIPTION
Firebase Instance ID has been replaced with FirebaseInstallations.

At this moment nobody is using that identifier so we remove it. If needed it will be restored in future with different API.