### PR TITLE
🐛 Update outdated peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A firebase plugin for Tabris.js",
   "types": "./types/index.d.ts",
   "peerDependencies": {
-    "tabris": "3.0.x"
+    "tabris": "^3.9.0-dev"
   },
   "cordova": {
     "id": "tabris-plugin-firebase",


### PR DESCRIPTION
Starting with `npm@7`, peer dependencies fail to install when they do not match the range declared for the peer dependency.

`tabris-plugin-firebase` declared only being compatible with the severely outdated `tabris@3.0.x`. Use the range `^3.9.0-dev` instead, which is compatible with latest stable and nightly Tabris.js 3.9 versions. Analogous to [1].

[1]: https://github.com/eclipsesource/tabris-decorators/commit/520562e5b31fc15ff24c308aad25d91c3e6f2d2a